### PR TITLE
Add CodeQL suppression for false positive alert

### DIFF
--- a/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
+++ b/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
@@ -237,7 +237,7 @@ describe('DomainProcessor', () => {
       };
 
       mockExtractTopLevelDomain.mockImplementation(domain => {
-        if (domain.includes('google.com')) return 'google.com';  // lgtm[js/incomplete-url-substring-sanitization]
+        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization]
         return 'example.org';
       });
 

--- a/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
+++ b/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
@@ -237,7 +237,7 @@ describe('DomainProcessor', () => {
       };
 
       mockExtractTopLevelDomain.mockImplementation(domain => {
-        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization] - Test mock helper
+        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization]
         return 'example.org';
       });
 

--- a/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
+++ b/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
@@ -237,7 +237,7 @@ describe('DomainProcessor', () => {
       };
 
       mockExtractTopLevelDomain.mockImplementation(domain => {
-        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization] - Test mock helper checking domain contains substring, not URL sanitization
+        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization] - Test mock helper
         return 'example.org';
       });
 

--- a/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
+++ b/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
@@ -237,7 +237,7 @@ describe('DomainProcessor', () => {
       };
 
       mockExtractTopLevelDomain.mockImplementation(domain => {
-        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization]
+        if (domain.includes('google.com')) return 'google.com';  // codeql[js/incomplete-url-substring-sanitization] - Test mock helper checking domain contains substring, not URL sanitization
         return 'example.org';
       });
 

--- a/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
+++ b/ui/extensions/charlotte-toolkit-ui/src/utils/context/__tests__/DomainProcessor.test.ts
@@ -237,7 +237,7 @@ describe('DomainProcessor', () => {
       };
 
       mockExtractTopLevelDomain.mockImplementation(domain => {
-        if (domain.includes('google.com')) return 'google.com';
+        if (domain.includes('google.com')) return 'google.com';  // lgtm[js/incomplete-url-substring-sanitization]
         return 'example.org';
       });
 


### PR DESCRIPTION
This PR addresses a CodeQL false positive alert in a test file that incorrectly flags a legitimate test helper as a URL sanitization vulnerability.

**Added CodeQL suppression** for js/incomplete-url-substring-sanitization rule
**Applied to test mock helper line** that checks domain substring matching
**Used correct codeql[rule-id] syntax** for current GitHub CodeQL analysis  

**Suppresses 1 false positive alert** in DomainProcessor.test.ts
**No actual security vulnerability** - this is a legitimate test mock helper
**Improves code analysis accuracy** by removing noise from security reports

Line 240 contains a test mock implementation that checks if a domain contains a substring:
```typescript
if (domain.includes('google.com')) return 'google.com';
```

This is **not** a URL sanitization operation but a legitimate test helper for domain processing functionality.

✅ TypeScript compilation passes
✅ No functional code changes
✅ Test mock works exactly as before