### PR TITLE
Fix iframe strict mode violation in E2E tests

### DIFF
--- a/e2e/src/pages/CharlotteExtensionPage.ts
+++ b/e2e/src/pages/CharlotteExtensionPage.ts
@@ -214,7 +214,7 @@ export class CharlotteExtensionPage extends SocketNavigationPage {
         }
 
         // Verify iframe loads
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+        await expect(this.page.locator('iframe').first()).toBeVisible({ timeout: 15000 });
         this.logger.info('Extension iframe loaded');
 
         // Verify iframe content


### PR DESCRIPTION
The Falcon console sometimes renders a hidden iframe alongside the app extension iframe, causing Playwright's strict mode to fail with "resolved to 2 elements" when using `locator('iframe')`. Adding `.first()` targets the first (visible) iframe and avoids the error.

This was causing nightly E2E test failures in CI.