### PR TITLE
Use specific iframe selector to avoid Charlotte AI conflict

### DIFF
--- a/e2e/src/pages/CharlotteExtensionPage.ts
+++ b/e2e/src/pages/CharlotteExtensionPage.ts
@@ -214,11 +214,11 @@ export class CharlotteExtensionPage extends SocketNavigationPage {
         }
 
         // Verify iframe loads
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+        await expect(this.page.locator('iframe[name="portal"]')).toBeVisible({ timeout: 15000 });
         this.logger.info('Extension iframe loaded');
 
         // Verify iframe content
-        const iframe: FrameLocator = this.page.frameLocator('iframe');
+        const iframe: FrameLocator = this.page.frameLocator('iframe[name="portal"]');
 
         // Check for Charlotte branding/title - looking for Charlotte Toolkit or Charlotte AI references
         const hasCharlotteContent = await Promise.race([


### PR DESCRIPTION
The Falcon console now includes a Charlotte AI iframe on every page. This causes Playwright's strict mode to fail with `locator('iframe') resolved to 2 elements` when the tests use the bare `iframe` selector.

This changes all iframe selectors from `iframe` to `iframe[name="portal"]` to specifically target the Foundry app iframe. The `name="portal"` attribute is set by the Foundry platform, so this selector works whether or not Charlotte AI is present.