### PR TITLE
Upgrade @crowdstrike/foundry-playwright to 0.5.1

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@crowdstrike/foundry-playwright": "0.5.0",
+        "@crowdstrike/foundry-playwright": "0.5.1",
         "@types/node": "25.6.0",
         "typescript": "6.0.3"
       }
     },
     "node_modules/@crowdstrike/foundry-playwright": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.0.tgz",
-      "integrity": "sha512-0dKup8mOEVT5KKJezfYVskOgk1zDh6MONyQ1EBdkQ4l1HfMbloZEJ4eMK+Opgww28yMCjhgsyuKp/qq4xmzURg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.1.tgz",
+      "integrity": "sha512-aB74uvvvfrOkHvy3jVfpeO3JPOjPdNHuMR+bUZyqUknFtZ4jBtquQMGWumspbXS+P78vDuI8c8BTVilnI2sscA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
-    "@crowdstrike/foundry-playwright": "0.5.0",
+    "@crowdstrike/foundry-playwright": "0.5.1",
     "@types/node": "25.6.0",
     "typescript": "6.0.3"
   }


### PR DESCRIPTION
Picks up retry loops for sidebar navigation and CI timing fixes.