### PR TITLE
Remove manifest IDs and increase e2e test timeout

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,3 +1,6 @@
 import { defineFoundryConfig } from '@crowdstrike/foundry-playwright';
 
-export default defineFoundryConfig();
+export default defineFoundryConfig({
+  timeout: 90_000,
+  retries: 2,
+});

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,3 @@
-app_id: c402448427134c72a46cbd4b492530ae
 name: Charlotte Toolkit
 description: AI-powered security analysis toolkit that leverages Charlotte AI to provide expert-level threat intelligence, automatic indicator extraction, and comprehensive security assessments
 logo: images/charlotte-logo.png
@@ -15,8 +14,7 @@ ignored:
 ui:
     homepage: ""
     extensions:
-        - id: 7296115e75164da19cb6f1e23f05d393
-          name: Charlotte Toolkit
+        - name: Charlotte Toolkit
           description: Charlotte Toolkit UI
           path: ui/extensions/charlotte-toolkit-ui/dist
           entrypoint: ui/extensions/charlotte-toolkit-ui/dist/index.html
@@ -72,8 +70,7 @@ auth:
     roles: []
 functions: []
 workflows:
-    - id: 15c13526f5084a0f9d119e88487eca50
-      name: Charlotte Toolkit Chat Completion
+    - name: Charlotte Toolkit Chat Completion
       path: workflows/Charlotte_Toolkit_Chat_Completion.yml
       permissions: []
 parsers: []
@@ -81,6 +78,5 @@ logscale:
     saved_searches: []
 lookup_files: []
 docs:
-    id: ae68a43504dc4e95b26cea169495b9a5
     path: app_docs
     entrypoint: README.md


### PR DESCRIPTION
Removes cloud-specific IDs from manifest.yml that were accidentally committed. These cause deploy conflicts when the app is deployed to different environments.

Also increases the Playwright test timeout from 45s to 90s and adds retries: 2. The NGSIEM Cases navigation can take 30-40s due to sidebar re-renders, which frequently exceeded the default timeout in CI.